### PR TITLE
Update to cdsw-custom Dockerfile

### DIFF
--- a/cdsw-custom/Dockerfile
+++ b/cdsw-custom/Dockerfile
@@ -28,8 +28,10 @@ RUN chmod +x /usr/local/bin/rstudio-cdsw
 
 # --- install Toree Kernel for Jupyter
 
+COPY . /opt/cloudera/parcels/CDH/lib/spark
 RUN pip install --no-cache-dir --upgrade toree
-# be sure to include 'jupyter toree install --spark_home=$SPARK_HOME --user' in your Jupyter startup command
+RUN jupyter toree install --sys-prefix --spark_home=/opt/cloudera/parcels/CDH/lib/spark
+RUN rm -rf /opt/cloudera
 
 
 


### PR DESCRIPTION
Improvement for `cdsw-custom` Dockerfile:
Install Apache Toree fully during container building by copying Cloudera Spark distribution to build context.